### PR TITLE
enable JDBC Connector to understand a null column scale

### DIFF
--- a/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialect.java
@@ -600,7 +600,8 @@ public class GenericDatabaseDialect implements DatabaseDialect {
         final int jdbcType = rs.getInt(5);
         final String typeName = rs.getString(6);
         final int precision = rs.getInt(7);
-        final int scale = rs.getInt(9);
+        int scale = rs.getInt(9);
+        scale = rs.wasNull() ? NUMERIC_TYPE_SCALE_UNSET : scale;
         final String typeClassName = null;
         Nullability nullability;
         final int nullableValue = rs.getInt(11);


### PR DESCRIPTION
getInt returns 0 if called to retrieve a value that is actually
null. This means that the connector can never see the difference
between a column with null scale and a column with 0 scale.

This change adds a check for null, and in combination with
https://github.com/pgjdbc/pgjdbc/commit/30843e45edc1e2bac499df2d1576c2db4d3d3309
allows improved handling of scale by letting the connector
differentiate between null and 0.

Signed-off-by: crwr45 <charlie.wheelerrobinson@gmail.com>